### PR TITLE
Dtspo 2915 starttls

### DIFF
--- a/exim.conf
+++ b/exim.conf
@@ -148,8 +148,8 @@ acl_smtp_data = acl_check_data
 
 # Allow any client to use TLS.
 
-# tls_advertise_hosts = *
-tls_advertise_hosts =
+tls_advertise_hosts = *
+#tls_advertise_hosts =
 
 # Specify the location of the Exim server's TLS certificate and private key.
 # The private key must not be encrypted (password protected). You can put
@@ -157,8 +157,9 @@ tls_advertise_hosts =
 # need the first setting, or in separate files, in which case you need both
 # options.
 
-tls_certificate = /etc/ssl/default-out/pemcert.crt
-tls_privatekey = /etc/ssl/default-out/pemkey.key
+tls_certificate = ${if exists{/etc/ssl/internal/${tls_sni}.crt}{/etc/ssl/internal/${tls_sni}.crt}{/etc/ssl/default-out/pemcert.crt}}
+
+tls_privatekey = ${if exists{/etc/ssl/internal/${tls_sni}.key}{/etc/ssl/internal/${tls_sni}.key}{/etc/ssl/default-out/pemkey.key}}
 
 # In order to support roaming users who wish to send email from anywhere,
 # you may want to make Exim listen on other ports as well as port 25, in
@@ -171,7 +172,7 @@ tls_privatekey = /etc/ssl/default-out/pemkey.key
 
 # Use 8025 internally.  The exim user can't attach to priviledged ports
 daemon_smtp_ports = 8025
-# tls_on_connect_ports = 465
+# tls_on_connect_ports = 8587
 
 
 # Specify the domain you want to be added to all unqualified addresses

--- a/exim.conf
+++ b/exim.conf
@@ -172,7 +172,7 @@ tls_privatekey = ${if exists{/etc/ssl/internal/${tls_sni}.key}{/etc/ssl/internal
 
 # Use 8025 internally.  The exim user can't attach to priviledged ports
 daemon_smtp_ports = 8025
-# tls_on_connect_ports = 8587
+# tls_on_connect_ports = 465
 
 
 # Specify the domain you want to be added to all unqualified addresses

--- a/helm/exim/templates/statefulsetOrdeployment.yaml
+++ b/helm/exim/templates/statefulsetOrdeployment.yaml
@@ -57,6 +57,11 @@ spec:
             name: mailrelay-dev-ssl
             readOnly: true
           {{- end }}
+          {{- if eq .Values.global.environment "dev" }}
+          - mountPath: "/etc/ssl/internal"
+            name: internal-mailrelay-dev-ssl
+            readOnly: true
+          {{- end }}
           {{- if .Values.fluentbit.enabled }}
           - mountPath: /var/log/exim
             name: log-volume
@@ -132,6 +137,14 @@ spec:
                 name: dev-mailrelay-cert
             - secret:
                 name: dev-mailrelay-key
+        {{- end }}
+        {{- if eq .Values.global.environment "dev" }}
+        - name: internal-mailrelay-dev-ssl
+          projected:
+            defaultMode: 0444
+            sources:
+            - secret:
+                name: internal-dev-mailrelay-tls
         {{- end }}
       {{- end }}
 

--- a/helm/exim/templates/statefulsetOrdeployment.yaml
+++ b/helm/exim/templates/statefulsetOrdeployment.yaml
@@ -59,7 +59,7 @@ spec:
           {{- end }}
           {{- if eq .Values.global.environment "dev" }}
           - mountPath: "/etc/ssl/internal"
-            name: internal-mailrelay-dev-ssl
+            name: internal-mailrelay-dev-tls
             readOnly: true
           {{- end }}
           {{- if .Values.fluentbit.enabled }}
@@ -139,7 +139,7 @@ spec:
                 name: dev-mailrelay-key
         {{- end }}
         {{- if eq .Values.global.environment "dev" }}
-        - name: internal-mailrelay-dev-ssl
+        - name: internal-mailrelay-dev-tls
           projected:
             defaultMode: 0444
             sources:


### PR DESCRIPTION
Logic so that if the set sni matches dev-in.mailrelay.internal.platform.hmcts.net the internal cert is used, if not - uses default cert.

Tested and verified with this config deployed to another exim instance, and using an image with swaks and ssl packages installed.
$ kubectl run -it --rm --restart=Never -n admin --image hannahlou/test-swaks:0.3 swaks --command -- bash
$ swaks --tls-sni dev-in.mailrelay.internal.platform.hmcts.net -tls -s 10.0.17.215 --tls-get-peer-cert

PR for adding cert and key - https://github.com/hmcts/shared-services-flux/pull/877

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
