### PR TITLE
Outbound certs, logic fixes, renaming

### DIFF
--- a/exim.conf
+++ b/exim.conf
@@ -157,9 +157,9 @@ tls_advertise_hosts = *
 # need the first setting, or in separate files, in which case you need both
 # options.
 
-tls_certificate = ${if exists{/etc/ssl/internal/${tls_sni}.crt}{/etc/ssl/internal/${tls_sni}.crt}{/etc/ssl/default-out/pemcert.crt}}
+tls_certificate = ${if exists{/etc/ssl/inbound/${tls_sni}.crt}{/etc/ssl/inbound/${tls_sni}.crt}{/etc/ssl/default-outbound/pemcert.crt}}
 
-tls_privatekey = ${if exists{/etc/ssl/internal/${tls_sni}.key}{/etc/ssl/internal/${tls_sni}.key}{/etc/ssl/default-out/pemkey.key}}
+tls_privatekey = ${if exists{/etc/ssl/inbound/${tls_sni}.key}{/etc/ssl/inbound/${tls_sni}.key}{/etc/ssl/default-outbound/pemkey.key}}
 
 # In order to support roaming users who wish to send email from anywhere,
 # you may want to make Exim listen on other ports as well as port 25, in
@@ -745,8 +745,8 @@ remote_smtp:
   headers_remove = received
   helo_data = ${env{HOSTNAME}{$value}{$primary_hostname}}
   hosts_require_tls = *
-  tls_certificate = /etc/ssl/default-out/pemcert.crt
-  tls_privatekey = /etc/ssl/default-out/pemkey.key
+  tls_certificate = /etc/ssl/default-outbound/pemcert.crt
+  tls_privatekey = /etc/ssl/default-outbound/pemkey.key
 
 
 # This transport is used for local delivery to user mailboxes in traditional

--- a/helm/exim/templates/inboundCertificateProviderClass.yaml
+++ b/helm/exim/templates/inboundCertificateProviderClass.yaml
@@ -2,7 +2,7 @@
 apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
 kind: SecretProviderClass
 metadata:
-  name: mailrelay-auth-keyvault-certificate-provider
+  name: mailrelay-inbound-keyvault-certificate-provider
 spec:
   provider: azure
   parameters:
@@ -12,12 +12,12 @@ spec:
     objects: |
       array:
       - |
-        objectName: {{ .Values.certificate.objectName }}
-        objectAlias: {{ .Values.certificate.name }}.{{ .Values.certificate.serverName }}.crt
-        objectType: cert 
+        objectName: {{ .Values.certificate.inboundCert.objectName }}
+        objectAlias: {{ .Values.certificate.inboundCert.name }}.{{ .Values.certificate.serverName }}.crt
+        objectType: cert
       - |
-        objectName: {{ .Values.certificate.objectName }}
-        objectAlias: {{ .Values.certificate.name }}.{{ .Values.certificate.serverName }}.key
+        objectName: {{ .Values.certificate.inboundCert.objectName }}
+        objectAlias: {{ .Values.certificate.inboundCert.name }}.{{ .Values.certificate.serverName }}.key
         objectType: key
     tenantId: {{ .Values.certificate.tenantId }}
 {{- end }}

--- a/helm/exim/templates/outboundCertificateProviderClass.yaml
+++ b/helm/exim/templates/outboundCertificateProviderClass.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.global.enableAuth }}
+apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
+kind: SecretProviderClass
+metadata:
+  name: mailrelay-outbound-keyvault-certificate-provider
+spec:
+  provider: azure
+  parameters:
+    usePodIdentity: "{{ .Values.usePodIdentity }}"
+    userAssignedIdentityID: "{{ .Values.managedIdentityClientId }}"
+    keyvaultName: {{ .Values.certificate.KeyVault }}
+    objects: |
+      array:
+      - |
+        objectName: {{ .Values.certificate.outboundCert.objectName }}
+        objectAlias: pemcert.crt
+        objectType: cert
+      - |
+        objectName: {{ .Values.certificate.outboundCert.objectName }}
+        objectAlias: pemcert.key
+        objectType: key
+    tenantId: {{ .Values.certificate.tenantId }}
+{{- end }}

--- a/helm/exim/templates/statefulsetOrdeployment.yaml
+++ b/helm/exim/templates/statefulsetOrdeployment.yaml
@@ -58,14 +58,14 @@ spec:
           - mountPath: "/var/spool/exim"
             name: {{ template "exim.name" . }}-data
           {{- end }}
-          {{- if .Values.global.enableTls }}
-          - mountPath: "/etc/ssl/default-out"
-            name: mailrelay-outbound-ssl
+          {{- if .Values.global.enableOutboundTls }}
+          - mountPath: "/etc/ssl/default-outbound"
+            name: exim-outbound-certs
             readOnly: true
           {{- end }}
           {{- if .Values.global.enableInboundTls }}
-          - mountPath: "/etc/ssl/internal"
-            name: exim-certs
+          - mountPath: "/etc/ssl/inbound"
+            name: exim-inbound-certs
             readOnly: true
           {{- end }}
           {{- if .Values.global.enableAuth }}
@@ -139,16 +139,6 @@ spec:
           persistentVolumeClaim:
             claimName: {{ template "exim.name" . }}-data
         {{- end }}
-        {{- if .Values.global.enableTls }}
-        - name: mailrelay-outbound-ssl
-          projected:
-            defaultMode: 0444
-            sources:
-            - secret:
-                name: {{ .Values.ssl.defaultOutCert }}
-            - secret:
-                name: {{ .Values.ssl.defaultOutKey }}
-        {{- end }}
         {{- if .Values.global.enableAuth }}
         - name: exim-passwd
           csi:
@@ -156,12 +146,22 @@ spec:
             readOnly: true
             volumeAttributes:
               secretProviderClass: "mailrelay-auth-keyvault-secret-provider"
-        - name: exim-certs
+        {{- end }}
+        {{- if .Values.global.enableOutboundTls }}
+        - name: exim-outbound-certs
           csi:
             driver: secrets-store.csi.k8s.io
             readOnly: true
             volumeAttributes:
-              secretProviderClass: "mailrelay-auth-keyvault-certificate-provider"
+              secretProviderClass: "mailrelay-outbound-keyvault-certificate-provider"
+        {{- end }}
+        {{- if .Values.global.enableInboundTls }}
+        - name: exim-inbound-certs
+          csi:
+            driver: secrets-store.csi.k8s.io
+            readOnly: true
+            volumeAttributes:
+              secretProviderClass: "mailrelay-inbound-keyvault-certificate-provider"
         {{- end }}
       {{- end }}
 

--- a/helm/exim/values.yaml
+++ b/helm/exim/values.yaml
@@ -43,7 +43,7 @@ service:
     port: 587
 
 global:
-  enableTls: false
+  enableOutboundTls: false
   enableInboundTls: false
   enableAuth: false
   environment: dev
@@ -96,11 +96,15 @@ authKeyVaultSecrets: []
 tenantId: 531ff96d-0ae9-462a-8d2d-bec7c0b42082
 
 certificate:
-  name: "dev-in"
-  objectName: "dev-in-mailrelay-platform-hmcts-net"
   serverName: "mailrelay.platform.hmcts.net"
   KeyVault: "acmedtssdsprod"
   tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
+  inboundCert:
+    name: "dev-in"
+    objectName: "dev-in-mailrelay-platform-hmcts-net"
+  outboundCert:
+    name: "dev"
+    objectName: "dev-mailrelay-platform-hmcts-net"
   
 fluentbit:
   enabled: false


### PR DESCRIPTION
Outbound certs added (I've generated these already)
Logic fix as {{- if .Values.global.enableAuth }} was also around certs
Some renaming as "internal" was removed - so now is just "inbound", changed some to outbound for readability


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
