### PR TITLE
DTSPO-4398: Update to use PEM format

### DIFF
--- a/exim.conf
+++ b/exim.conf
@@ -157,9 +157,9 @@ tls_advertise_hosts = *
 # need the first setting, or in separate files, in which case you need both
 # options.
 
-tls_certificate = ${if exists{/etc/ssl/inbound/${tls_sni}.crt}{/etc/ssl/inbound/${tls_sni}.crt}{/etc/ssl/default-outbound/pemcert.crt}}
+tls_certificate = ${if exists{/etc/ssl/inbound/${tls_sni}.pem}{/etc/ssl/inbound/${tls_sni}.pem}{/etc/ssl/default-outbound/pemcert.pem}}
 
-tls_privatekey = ${if exists{/etc/ssl/inbound/${tls_sni}.key}{/etc/ssl/inbound/${tls_sni}.key}{/etc/ssl/default-outbound/pemkey.key}}
+# tls_privatekey = ${if exists{/etc/ssl/inbound/${tls_sni}.key}{/etc/ssl/inbound/${tls_sni}.key}{/etc/ssl/default-outbound/pemkey.key}}
 
 # In order to support roaming users who wish to send email from anywhere,
 # you may want to make Exim listen on other ports as well as port 25, in
@@ -745,8 +745,8 @@ remote_smtp:
   headers_remove = received
   helo_data = ${env{HOSTNAME}{$value}{$primary_hostname}}
   hosts_require_tls = *
-  tls_certificate = /etc/ssl/default-outbound/pemcert.crt
-  tls_privatekey = /etc/ssl/default-outbound/pemkey.key
+  tls_certificate = /etc/ssl/default-outbound/pemcert.pem
+#   tls_privatekey = /etc/ssl/default-outbound/pemkey.key
 
 
 # This transport is used for local delivery to user mailboxes in traditional

--- a/helm/exim/templates/inboundCertificateProviderClass.yaml
+++ b/helm/exim/templates/inboundCertificateProviderClass.yaml
@@ -13,11 +13,8 @@ spec:
       array:
       - |
         objectName: {{ .Values.certificate.inboundCert.objectName }}
-        objectAlias: {{ .Values.certificate.inboundCert.name }}.{{ .Values.certificate.serverName }}.crt
-        objectType: cert
-      - |
-        objectName: {{ .Values.certificate.inboundCert.objectName }}
-        objectAlias: {{ .Values.certificate.inboundCert.name }}.{{ .Values.certificate.serverName }}.key
-        objectType: key
+        objectAlias: {{ .Values.certificate.inboundCert.name }}.{{ .Values.certificate.serverName }}.pem
+        objectType: secret
+        objectFormat: "pem"
     tenantId: {{ .Values.certificate.tenantId }}
 {{- end }}

--- a/helm/exim/templates/outboundCertificateProviderClass.yaml
+++ b/helm/exim/templates/outboundCertificateProviderClass.yaml
@@ -13,11 +13,8 @@ spec:
       array:
       - |
         objectName: {{ .Values.certificate.outboundCert.objectName }}
-        objectAlias: pemcert.crt
-        objectType: cert
-      - |
-        objectName: {{ .Values.certificate.outboundCert.objectName }}
-        objectAlias: pemkey.key
-        objectType: key
+        objectAlias: pemcert.pem
+        objectType: secret
+        objectFormat: "pem"
     tenantId: {{ .Values.certificate.tenantId }}
 {{- end }}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-4398


### Change description ###
While testing there seem to be errors from cert and key generated by the csi driver, exim complains that the key is invalid. Swapping to use just the PEM format to see if this is acceptable by the application.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
