### PR TITLE
DTSPO-9393: Update secrets mail relay

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+# https://help.github.com/en/articles/about-code-owners
+
+CODEOWNERS @hmcts/platform-operations

--- a/README.md
+++ b/README.md
@@ -176,14 +176,14 @@ This can all be configured using the following variables (see also [helm/exim-re
 
 The following table lists the configurable parameters of the chart and their default values (see variables section for a description).
 
-| Parameter                  | Variable         | Default  |
-| -------------------------- | ---------------- | ----- |
-| `relayHost`                | SMARTHOST        | `smtp.example.com::587` |
-| `relayHostname`            | HOSTNAME         | `my.host.local`|
-| `relayFromHosts`           | RELAY_FROM_HOSTS | `10.0.0.0/8,127.0.0.0/8,172.17.0.0/16,192.0.0.0/8` |
-| `relayUsername`            | SMTP_USERNAME    | `relayuser` | 
-| `relayPassword`            | SMTP_PASSWORD    | `relaypassword` |
-| `relayToDomains`           | RELAY_TO_DOMAINS | `*`|
-| `localDomains`             | LOCAL_DOMAINS    | ``|
-| `relayToUsers`             | RELAY_TO_USERS   | ``|
-| `relayDisableSenderVerification` | DISABLE_SENDER_VERIFICATION | `false` |
+| Parameter                  | Variable         | Location | Default  |
+| -------------------------- | ---------------- | -------- | -------- |
+| `relayHost`                | SMARTHOST        |  `CSI`  | `smtp.example.com::587` |
+| `relayHostname`            | HOSTNAME         |  `CSI`  | `my.host.local` |
+| `relayFromHosts`           | RELAY_FROM_HOSTS |  `CSI`  | `10.0.0.0/8,127.0.0.0/8,172.17.0.0/16,192.0.0.0/8` |
+| `relayToDomains`           | RELAY_TO_DOMAINS |  `CSI`  | `*` |
+| `relayUsername`            | SMTP_USERNAME    |  `SOPS` | `relayuser` |
+| `relayPassword`            | SMTP_PASSWORD    |  `SOPS` | `relaypassword` |
+| `localDomains`             | LOCAL_DOMAINS    |  `SOPS` | `` |
+| `relayToUsers`             | RELAY_TO_USERS   |  `SOPS` | `` |
+| `relayDisableSenderVerification` | DISABLE_SENDER_VERIFICATION | `YAML` | `false` |

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ This can all be configured using the following variables (see also [helm/exim-re
 
 The following table lists the configurable parameters of the chart and their default values (see variables section for a description).
 
-| Parameter                  | Variable         | Location | Default  |
+| Parameter                  | Variable         | Source   | Default  |
 | -------------------------- | ---------------- | -------- | -------- |
 | `relayHost`                | SMARTHOST        |  `CSI`  | `smtp.example.com::587` |
 | `relayHostname`            | HOSTNAME         |  `CSI`  | `my.host.local` |

--- a/helm/exim/templates/configmap.yaml
+++ b/helm/exim/templates/configmap.yaml
@@ -8,11 +8,8 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
-  # These values have been removed and are now retrieved via CSI
-  # SMARTHOST: '{{ .Values.smtp.relayHost }}'
-  # HOSTNAME: '{{ .Values.smtp.relayHostname }}'
-  # RELAY_FROM_HOSTS: '{{ .Values.smtp.relayFromHosts }}'
-  # RELAY_TO_DOMAINS: '{{ .Values.smtp.relayToDomains }}'
+  # At the moment, these values have been removed and are set as deployment env
+  # SMARTHOST, HOSTNAME, RELAY_FROM_HOSTS, RELAY_TO_DOMAINS
   LOCAL_DOMAINS: '{{ .Values.smtp.localDomains }}'
   SMTP_USERNAME: '{{ .Values.smtp.relayUsername }}'
   RELAY_TO_USERS: '{{ .Values.smtp.relayToUsers }}'
@@ -41,7 +38,7 @@ data:
         HTTP_Listen   0.0.0.0
         HTTP_Port     2020
         # Plugins_File /fluent-bit/etc/plugins.conf
-  
+
     @INCLUDE input-exim.conf
     @INCLUDE filter-exim.conf
     @INCLUDE output-stdout.conf
@@ -94,5 +91,5 @@ data:
         Format      regex
         Regex       ^\<(?<pri>[0-9]+)\>(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$
         Time_Key    time
-        Time_Format %b %d %H:%M:%S    
+        Time_Format %b %d %H:%M:%S
 {{- end }}

--- a/helm/exim/templates/configmap.yaml
+++ b/helm/exim/templates/configmap.yaml
@@ -8,12 +8,13 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
-  SMARTHOST: '{{ .Values.smtp.relayHost }}'
-  HOSTNAME: '{{ .Values.smtp.relayHostname }}'
-  RELAY_FROM_HOSTS: '{{ .Values.smtp.relayFromHosts }}'
+  # These values have been removed and are now retrieved via CSI
+  # SMARTHOST: '{{ .Values.smtp.relayHost }}'
+  # HOSTNAME: '{{ .Values.smtp.relayHostname }}'
+  # RELAY_FROM_HOSTS: '{{ .Values.smtp.relayFromHosts }}'
+  # RELAY_TO_DOMAINS: '{{ .Values.smtp.relayToDomains }}'
   LOCAL_DOMAINS: '{{ .Values.smtp.localDomains }}'
   SMTP_USERNAME: '{{ .Values.smtp.relayUsername }}'
-  RELAY_TO_DOMAINS: '{{ .Values.smtp.relayToDomains }}'
   RELAY_TO_USERS: '{{ .Values.smtp.relayToUsers }}'
   DISABLE_SENDER_VERIFICATION: '{{ .Values.smtp.relayDisableSenderVerification }}'
 {{- if .Values.fluentbit.enabled }}

--- a/helm/exim/templates/envSecretsProviderClass.yaml
+++ b/helm/exim/templates/envSecretsProviderClass.yaml
@@ -13,7 +13,7 @@ spec:
     - objectName: relayHost                   
       key: relayhost
     - objectName: relayHostname                   
-      key: relayhost
+      key: relayhostname
     - objectName: relayFromHosts                   
       key: relayfromhosts
     - objectName: relayToDomains                   
@@ -31,7 +31,7 @@ spec:
       - |
         objectName: "relayHostname"
         objectType: secret
-        objectAlias: relayhost
+        objectAlias: relayhostname
       - |
         objectName: "relayFromHosts"
         objectType: secret

--- a/helm/exim/templates/envSecretsProviderClass.yaml
+++ b/helm/exim/templates/envSecretsProviderClass.yaml
@@ -21,7 +21,7 @@ spec:
   parameters:
     usePodIdentity: "{{ .Values.usePodIdentity }}"
     userAssignedIdentityID: "{{ .Values.managedIdentityClientId }}"
-    keyvaultName: {{ .Values.certificate.KeyVault }}
+    keyvaultName: {{ .Values.authKeyVaultName }}-{{ .Values.global.environment }}
     objects: |
       array:
       - |

--- a/helm/exim/templates/envSecretsProviderClass.yaml
+++ b/helm/exim/templates/envSecretsProviderClass.yaml
@@ -1,0 +1,40 @@
+apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
+kind: SecretProviderClass
+metadata:
+  name: exim-mailrelay-env-secrets-provider
+spec:
+  provider: azure
+    secretObjects:                                 
+  - secretName: eximenvsecrets
+    type: Opaque
+    labels:                                   
+      environment: {{ .Values.global.environment }}-secrets
+    data: 
+    - objectName: relayHost                   
+      key: relayhost
+  parameters:
+    usePodIdentity: "{{ .Values.usePodIdentity }}"
+    userAssignedIdentityID: "{{ .Values.managedIdentityClientId }}"
+    keyvaultName: {{ .Values.certificate.KeyVault }}
+    objects: |
+      array:
+      - |
+        objectName: "relayHost"
+        objectType: secret
+        objectAlias: relayhost
+      - |
+        objectName: "relayHostname"
+        objectType: secret
+        objectAlias: relayhost
+      - |
+        objectName: "relayFromHosts"
+        objectType: secret
+        objectAlias: relayfromhosts
+      - |
+        objectName: "relayToDomains"
+        objectType: secret
+        objectAlias: relaytodomains
+
+    tenantId: {{ .Values.certificate.tenantId }}
+
+  

--- a/helm/exim/templates/envSecretsProviderClass.yaml
+++ b/helm/exim/templates/envSecretsProviderClass.yaml
@@ -12,6 +12,12 @@ spec:
     data: 
     - objectName: relayHost                   
       key: relayhost
+    - objectName: relayHostname                   
+      key: relayhost
+    - objectName: relayFromHosts                   
+      key: relayfromhosts
+    - objectName: relayToDomains                   
+      key: relaytodomains
   parameters:
     usePodIdentity: "{{ .Values.usePodIdentity }}"
     userAssignedIdentityID: "{{ .Values.managedIdentityClientId }}"

--- a/helm/exim/templates/statefulsetOrdeployment.yaml
+++ b/helm/exim/templates/statefulsetOrdeployment.yaml
@@ -99,7 +99,7 @@ spec:
             name: log-volume
           {{- end }}
           - mountPath: "/etc/exim/secrets"
-            name: exim-mailrelay-env-secrets-provider
+            name: exim-mailrelay-env-secrets
             readOnly: true
         {{- end }}
  

--- a/helm/exim/templates/statefulsetOrdeployment.yaml
+++ b/helm/exim/templates/statefulsetOrdeployment.yaml
@@ -47,6 +47,12 @@ spec:
             name: {{ template "exim.fullname" . }}
         - secretRef:
             name: {{ template "exim.fullname" . }}
+        env:
+        - name: SMARTHOST
+          valueFrom:
+            secretKeyRef:
+              name: eximenvsecrets
+              key: relayhost
         ports:
           - name: smtp
             containerPort: 25
@@ -73,11 +79,15 @@ spec:
             name: exim-passwd
             readOnly: true
           {{- end }}
-          {{- if .Values.fluentbit.enabled }}
+          {{- if .Values.fluentbit.enabled }}          
           - mountPath: /var/log/exim
             name: log-volume
           {{- end }}
+          - mountPath: "/etc/exim/secrets"
+            name: exim-mailrelay-env-secrets-provider
+            readOnly: true
         {{- end }}
+ 
         resources:
 {{ toYaml .Values.resources | indent 10 }}
       {{- if .Values.fluentbit.enabled }}
@@ -163,6 +173,12 @@ spec:
             volumeAttributes:
               secretProviderClass: "mailrelay-inbound-keyvault-certificate-provider"
         {{- end }}
+        - name: exim-mailrelay-env-secrets
+          csi:
+            driver: secrets-store.csi.k8s.io
+            readOnly: true
+            volumeAttributes:
+              secretProviderClass: "exim-mailrelay-env-secrets-provider"
       {{- end }}
 
   {{- if eq .Values.workload "StatefulSet" }}

--- a/helm/exim/templates/statefulsetOrdeployment.yaml
+++ b/helm/exim/templates/statefulsetOrdeployment.yaml
@@ -57,7 +57,7 @@ spec:
           valueFrom:
             secretKeyRef:
               name: eximenvsecrets
-              key: relayhost      
+              key: relayhostname    
         - name: RELAY_FROM_HOSTS
           valueFrom:
             secretKeyRef:

--- a/helm/exim/templates/statefulsetOrdeployment.yaml
+++ b/helm/exim/templates/statefulsetOrdeployment.yaml
@@ -53,19 +53,16 @@ spec:
             secretKeyRef:
               name: eximenvsecrets
               key: relayhost
-        env:
         - name: HOSTNAME
           valueFrom:
             secretKeyRef:
               name: eximenvsecrets
               key: relayhost      
-        env:
         - name: RELAY_FROM_HOSTS
           valueFrom:
             secretKeyRef:
               name: eximenvsecrets
               key: relayfromhosts
-        env:
         - name: RELAY_TO_DOMAINS
           valueFrom:
             secretKeyRef:

--- a/helm/exim/templates/statefulsetOrdeployment.yaml
+++ b/helm/exim/templates/statefulsetOrdeployment.yaml
@@ -53,6 +53,24 @@ spec:
             secretKeyRef:
               name: eximenvsecrets
               key: relayhost
+        env:
+        - name: HOSTNAME
+          valueFrom:
+            secretKeyRef:
+              name: eximenvsecrets
+              key: relayhost      
+        env:
+        - name: RELAY_FROM_HOSTS
+          valueFrom:
+            secretKeyRef:
+              name: eximenvsecrets
+              key: relayfromhosts
+        env:
+        - name: RELAY_TO_DOMAINS
+          valueFrom:
+            secretKeyRef:
+              name: eximenvsecrets
+              key: relaytodomains
         ports:
           - name: smtp
             containerPort: 25

--- a/helm/exim/values.yaml
+++ b/helm/exim/values.yaml
@@ -56,11 +56,8 @@ volumeClaim:
 
 # SMTP server details
 # Used by exim to connect to SMTP server
-# The following has been removed as they are now retrived via CSI
-# relayHost: "smtp.example.com::587"
-# relayHostname: "my.host.local"
-# relayFromHosts: ""
-# relayToDomains: ""
+# At the moment the following has been removed as they are now retrived via CSI
+# relayHost, relayHostname, relayFromHosts and relayToDomains
 smtp:
   relayUsername: "relayuser"
   relayPassword: "relaypassword"

--- a/helm/exim/values.yaml
+++ b/helm/exim/values.yaml
@@ -56,14 +56,14 @@ volumeClaim:
 
 # SMTP server details
 # Used by exim to connect to SMTP server
+# The following has been removed as they are now retrived via CSI
+# relayHost: "smtp.example.com::587"
+# relayHostname: "my.host.local"
+# relayFromHosts: ""
+# relayToDomains: ""
 smtp:
-  # Example with example
-  relayHost: "smtp.example.com::587"
-  relayHostname: "my.host.local"
-  relayFromHosts: ""
   relayUsername: "relayuser"
   relayPassword: "relaypassword"
-  relayToDomains: ""
   localDomains: ""
   relayToUsers: ""
   relayDisableSenderVerification: false


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSPO-9393

### Change description ###

A couple of environment variables where maintained via `SOPS`. These values would be better managed as secrets. Main issues is that they are mostly in default state and we cant have empty values as secretes in a Keyvault.

The plan in the sort term is to move those variable that have values to be managed via `CSI` to make it easier in changing values while those that are at their default remain in `SOPS` as they would mostly not change.

In the long run, whenever configuration changes, as mailrelay evolves, when needed, it would be easy to move a particular variable to the keyvault and update the configuration.

The environment definition in the deployment file is verbose, items assigned are listed in the `env` section

The secret definition are found in the `envSecretsProviderClass` yaml and the main `configuration` yaml file has also been update to not declare these values as they would not come from the secret file above.

These values would also be removed from the `SOPS` encrypted  flux values file in the `sds-flux-config` repo.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
