### PR TITLE
Remove unneeded guard on aadpodidbinding

### DIFF
--- a/helm/exim/templates/statefulsetOrdeployment.yaml
+++ b/helm/exim/templates/statefulsetOrdeployment.yaml
@@ -7,9 +7,7 @@ metadata:
     chart: {{ template "exim.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-    {{- if .Values.global.enableAuth }}
     aadpodidbinding: {{ .Values.aadIdentityName }}
-    {{- end }}
   annotations:
     {{- if .Values.prometheus.enabled }}
     prometheus.io/scrape: "true"
@@ -28,9 +26,7 @@ spec:
       labels:
         app: {{ template "exim.name" . }}
         release: {{ .Release.Name }}
-        {{- if .Values.global.enableAuth }}
         aadpodidbinding: {{ .Values.aadIdentityName }}
-        {{- end }}
     spec:
       serviceAccountName: {{ template "exim.serviceAccountName" . }}
       shareProcessNamespace: true

--- a/helm/exim/values.yaml
+++ b/helm/exim/values.yaml
@@ -86,7 +86,7 @@ tolerations: []
 affinity: {}
 
 aadIdentityName: mailrelay
-usePodIdentity: "false"
+usePodIdentity: "true"
 managedIdentityClientId: c4acf9cf-3120-4b87-baa9-3916ffd293eb
 authKeyVaultName: sds-mailrelay
 authKeyVaultSecrets: []


### PR DESCRIPTION
Looks like mailrelay v1 needs pod id to load a few values but enableAuth was linked to that